### PR TITLE
Update package setup to use yaml config file.

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -43,3 +43,25 @@ binaries:
     "Linux_armv8":
       url: "https://cdn.azul.com/zulu-embedded/bin/zulu8.54.0.21-ca-jdk8.0.292-linux_aarch64.tar.gz"
       sha256: "5eb9a61c60e89d262167bf99855b79115ca8e16b1b8bdc1cd3ad1ed4f0d163ac"
+  "8.0.332":
+    "Windows_x86":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.62.0.19-ca-jdk8.0.332-win_i686.zip"
+      sha256: "8f4b7dd1fab73fb853681bfecf5cbeeb92587257200c245c449a9d924f6d92de"
+    "Windows_x86_64":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.62.0.19-ca-jdk8.0.332-win_x64.zip"
+      sha256: "6b24680b7c241a239ab070e4f5aea0fc94b3c6e17303c0fc40dcd8524815bfc2"
+    "Macos_x86_64":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.62.0.19-ca-jdk8.0.332-macosx_x64.tar.gz"
+      sha256: "9b2a14112de141bdcef0ee34a57072b3310568b365ca5ecf54724a8100039339"
+    "Macos_armv8":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.62.0.19-ca-jdk8.0.332-macosx_aarch64.tar.gz"
+      sha256: "e5c84a46bbd985c3a53358db9c97a6fd4930f92b833c3163a0d1e47dab59768c"
+    "Linux_x86":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.62.0.19-ca-jdk8.0.332-linux_i686.tar.gz"
+      sha256: "9a755765d58e4d8ab14cf080a206815c7070cc719086f1fe41a22cdbf1374b05"
+    "Linux_x86_64":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.62.0.19-ca-jdk8.0.332-linux_x64.tar.gz"
+      sha256: "bfe6fa049797ea996e5a7252279f4bb99d5e8f2227be6c3b98e9c78e3d916fc9"
+    "Linux_armv8":
+      url: "https://cdn.azul.com/zulu-embedded/bin/zulu8.62.0.19-ca-jdk8.0.332-linux_aarch64.tar.gz"
+      sha256: "c4519172d6f5323192561108ee25c2cdef2b7ab0d7f9c807d95a7cf5d4209e84"

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,0 +1,45 @@
+binaries:
+  "8.0.282":
+    "Windows_x86":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-win_i686.zip"
+      sha256: "989ce40a44c32b75826668d28b96ad75bb037b8d83e8cccdd222cecff50ab7e6"
+    "Windows_x86_64":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-win_x64.zip"
+      sha256: "af76e1a483ec7a119716e4b9c2f4c050ce413b5b15afe66563f25048a1b00220"
+    "Macos_x86_64":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-macosx_x64.tar.gz"
+      sha256: "3c8ba3629d9f896a4f5edd2021ee1e7b5b9fb9c4a6866c96dbae1adb9424df9e"
+    "Macos_armv8":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-macosx_aarch64.tar.gz"
+      sha256: "011845318d37567ff2cb63d0f9115dd251504dc0d9156c9b7d9c4213a032c3be"
+    "Linux_x86":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-linux_i686.tar.gz"
+      sha256: "d68bd05d36a4da4774a5211eaca2870eda632410df19fe1dabb5adf9906c54c3"
+    "Linux_x86_64":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-linux_x64.tar.gz"
+      sha256: "36c39878724f509d765a8f3804f6cef87c2eff39ac85447a0dc870231c1d3bca"
+    "Linux_armv8":
+      url: "https://cdn.azul.com/zulu-embedded/bin/zulu8.52.0.23-ca-jdk8.0.282-linux_aarch64.tar.gz"
+      sha256: "ae0ad6046f6e7e751b43c615e3d37afc8b6b1c19b88dffd5f22c225aae9d26a7"
+  "8.0.292":
+    "Windows_x86":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.54.0.21-ca-fx-jdk8.0.292-win_i686.zip"
+      sha256: "183b7322bb42dee32b77a72d126d6354551f1361a702fa4adccca8020bbaa94c"
+    "Windows_x86_64":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.54.0.21-ca-fx-jdk8.0.292-win_x64.zip"
+      sha256: "84efdbd536497f5f21ef4412e2045b637255d135be873ea05184f1f7924c3828"
+    "Macos_x86_64":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.54.0.21-ca-fx-jdk8.0.292-macosx_x64.tar.gz"
+      sha256: "e671f8990229b1ca2a76faabb21ba2f1a9e1f7211392e0f657225559be9b05c8"
+    "Macos_armv8":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.54.0.21-ca-fx-jdk8.0.292-macosx_aarch64.tar.gz"
+      sha256: "8e901075cde2c31f531a34e8321ea4201970936abf54240a232e9389952afe84"
+    "Linux_x86":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.54.0.21-ca-fx-jdk8.0.292-linux_i686.tar.gz"
+      sha256: "eb181e71db09192d9dee941d3a946f1a0ee2550f8a05641845e6a7ac628106d9"
+    "Linux_x86_64":
+      url: "https://cdn.azul.com/zulu/bin/zulu8.54.0.21-ca-fx-jdk8.0.292-linux_x64.tar.gz"
+      sha256: "19985150dcea937d3899881bdd1d92ff384b3c018106868350677f37c245996e"
+    "Linux_armv8":
+      url: "https://cdn.azul.com/zulu-embedded/bin/zulu8.54.0.21-ca-jdk8.0.292-linux_aarch64.tar.gz"
+      sha256: "5eb9a61c60e89d262167bf99855b79115ca8e16b1b8bdc1cd3ad1ed4f0d163ac"

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,79 +2,67 @@
 # -*- coding: utf-8 -*-
 import os
 import platform
+
 from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
 
 
-class JavaInstallerConan(ConanFile):
+class ZuluOpenJDKConan(ConanFile):
     name = 'java_installer'
-    version = '8.0.252'
-    url = 'https://github.com/bincrafters/conan-java_installer'
+    url = 'https://github.com/datalogics/conan-java_installer'
     description = 'Java installer distributed via Conan'
-    license = 'https://www.azul.com/products/zulu-and-zulu-enterprise/zulu-terms-of-use/'
+    license = 'https://azul.com'
+    topics = ("java", "jdk", "openjdk")
     settings = 'os', 'arch'
 
     @property
-    def jni_folder(self):
-        folder = {'Linux': 'linux', 'Darwin': 'darwin',
-                  'Windows': 'win32'}.get(platform.system())
+    def _jni_folder(self):
+        folder = {'Linux': 'linux',
+                  'Macos': 'darwin',
+                  'Windows': 'win32',
+                  'AIX': 'aix',
+                  'SunOS': 'solaris'}.get(str(self.settings.os))
         return os.path.join('include', folder)
 
+    @property
+    def _binary_key(self):
+        return '{0}_{1}'.format(self.settings.os, self.settings.arch)
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
     def config_options(self):
-        # Checking against self.settings.* would prevent cross-building profiles from working
-        if self.settings.arch not in ['x86_64', 'x86']:
-            raise Exception(
-                'Unsupported Architecture.  This package currently only supports x86_64 and x86.')
-        if self.settings.os not in ['Windows', 'Macos', 'Linux']:
-            raise Exception(
-                'Unsupported System. This package currently only support Linux/Darwin/Windows')
+        data = self.conan_data["binaries"][self.version].get(self._binary_key, None)
+        if data is None:
+            raise ConanInvalidConfiguration("Unsupported Architecture.  No data was found in {0} for OS "
+                                            "{1} with arch {2}".format(self.version, self.settings.os,
+                                                                       self.settings.arch))
         if self.settings.os == 'Macos' and self.settings.arch == 'x86':
-            raise Exception('Unsupported System (32-bit Mac OS X)')
+            raise ConanInvalidConfiguration(
+                'Unsupported System (32-bit Mac OS X)')
 
     def build(self):
-        x64 = self.settings.arch == 'x86_64'
-        source_file = 'zulu8.{0}-ca-jdk{1}-{2}_{3}'
-        zulu_version = '46.0.19'
-        ext = 'tar.gz'
-        arch = 'x64' if x64 else 'i686'
-        if self.settings.os == 'Windows':
-            source_file = source_file.format(
-                zulu_version, self.version, 'win', arch)
-            ext = 'zip'
-            if x64:
-                checksum = '993ef31276d18446ef8b0c249b40aa2dfcea221a5725d9466cbea1ba22686f6b'
-            else:
-                checksum = '44fa7abc0f647a014b2c6a6cf78000cc2a554b15132ea83e60229ea58a77c551'
-        elif self.settings.os == 'Linux':
-            source_file = source_file.format(
-                zulu_version, self.version, 'linux', arch)
-            if x64:
-                checksum = 'ab8a4194006f12dd48bf7f176ca7879706d3f8fc7d3208313a46cc9ee2270716'
-            else:
-                checksum = 'bba0ec1606823515172e3eee9fcaa9ea29d51be49ee903c4b1e708af3e60a29f'
-        elif self.settings.os == 'Macos':
-            source_file = source_file.format(
-                zulu_version, self.version, 'macosx', arch)
-            checksum = '43570b0a6455a02d25b0c4937164560fdb0a9478f9010c583f510fa80881ce0b'
-
-        bin_filename = '{0}.{1}'.format(source_file, ext)
-        download_url = 'http://cdn.azul.com/zulu/bin/{0}'.format(bin_filename)
-        self.output.info('Downloading : {0}'.format(download_url))
-        tools.get(download_url, sha256=checksum)
-        os.rename(source_file, 'sources')
+        self.output.info('Downloading {0}'.format(
+            self.conan_data["binaries"][self.version][self._binary_key].get('url')))
+        tools.get(**self.conan_data["binaries"][self.version][self._binary_key],
+                  destination=self._source_subfolder, strip_root=True)
 
     def package(self):
-        self.copy(pattern='*', dst='.', src='sources')
+        self.copy(pattern='*', dst='.', src=self._source_subfolder)
+
+    def package_id(self):
+        del self.info.settings.os.version
 
     def package_info(self):
-        self.cpp_info.includedirs.append(self.jni_folder)
-
-        java_home = os.path.join(self.package_folder)
-        bin_path = os.path.join(java_home, 'bin')
-
+        self.cpp_info.includedirs.append(self._jni_folder)
+        self.cpp_info.bindirs = ['bin']
+        self.cpp_info.libdirs = []
+        java_home = self.package_folder
         self.output.info(
             'Creating JAVA_HOME environment variable with : {0}'.format(java_home))
         self.env_info.JAVA_HOME = java_home
-
+        bin_path = os.path.join(java_home, 'bin')
         self.output.info(
-            'Appending PATH environment variable with : {0}'.format(bin_path))
+            'Prepending PATH environment variable with : {0}'.format(bin_path))
         self.env_info.PATH.append(bin_path)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,6 +1,19 @@
-from conans import ConanFile
+from conans import ConanFile, tools
+from six import StringIO
 
 
-class TestPackage(ConanFile):        
+class TestPackage(ConanFile):
+    def build(self):
+        pass # nothing to build, but tests should not warn
+
     def test(self):
-        self.run("java -version")
+        if tools.cross_building(self.settings):
+            return
+        test_cmd = ['java', '-version']
+        output = StringIO()
+        self.run(test_cmd, output=output)
+        version_info = output.getvalue()
+        if "Zulu" in version_info:
+            pass
+        else:
+            raise Exception("java call seems not use the Zulu OpenJDK bin:\n{0}".format(version_info))


### PR DESCRIPTION
There IS a zulu openjdk package in conan-center-index, but it only
supports x86_64 architecture, and JDK 11.  Trying to get that
recipe to package JDK 8 proved to be complicated, so here we just
roll our own package similar to the AdoptOpen JDK package we also maintain.
